### PR TITLE
mk/checkconf.mk: guard should not depend on path

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -17,7 +17,7 @@ define check-conf-h
 	cnf='$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,$1),			\
 		$(call cfg-make-define,$(var))))';		\
-	guard="_`echo $@ | tr -- -/. ___`_";			\
+	guard="_CONFIG_H_";					\
 	mkdir -p $(dir $@);					\
 	echo "#ifndef $${guard}" >$@.tmp;			\
 	echo "#define $${guard}" >>$@.tmp;			\


### PR DESCRIPTION
Currently the guard in config.h depends on the build path. If the build
path includes characters like '-' or '+' this leads to build errors:

make -C /<<BUILDDIR>>/nezha-boot0-1.0.1+11+g70d35f2/arch/riscv/cpu/riscv64/
In file included from boot0_entry.S:7:
/<<BUILDDIR>>/nezha-boot0-1.0.1+11+g70d35f2/include/config.h:1:53:
error: extra tokens at end of #ifndef directive [-Werror]

Use a predefined guard.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>