### PR TITLE
config.mk: Allow overriding CC and other tools

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -6,16 +6,16 @@ ifneq ($(SKIP_AUTO_CONF),yes)
 sinclude $(TOPDIR)/autoconf.mk
 endif
 
-AS		= $(CROSS_COMPILE)as
-LD		= $(CROSS_COMPILE)ld
-CC		= $(CROSS_COMPILE)gcc
-CPP		= $(CC) -E
-AR		= $(CROSS_COMPILE)ar
-NM		= $(CROSS_COMPILE)nm
-LDR		= $(CROSS_COMPILE)ldr
-STRIP		= $(CROSS_COMPILE)strip
-OBJCOPY		= $(CROSS_COMPILE)objcopy
-OBJDUMP		= $(CROSS_COMPILE)objdump
+AS		?= $(CROSS_COMPILE)as
+LD		?= $(CROSS_COMPILE)ld
+CC		?= $(CROSS_COMPILE)gcc
+CPP		?= $(CC) -E
+AR		?= $(CROSS_COMPILE)ar
+NM		?= $(CROSS_COMPILE)nm
+LDR		?= $(CROSS_COMPILE)ldr
+STRIP		?= $(CROSS_COMPILE)strip
+OBJCOPY		?= $(CROSS_COMPILE)objcopy
+OBJDUMP		?= $(CROSS_COMPILE)objdump
 
 ##########################################################
 ifeq (x$(CPU), xriscv64)


### PR DESCRIPTION
It helps build systems defaults to be used e.g. OE's default CC has
additional bits which are needed for regular functioning of the cross
compiler.

Signed-off-by: Khem Raj <raj.khem@gmail.com>