### PR TITLE
config.mk: Remove -nostdinc and use -ffreestanding

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -30,7 +30,7 @@ SPLINCLUDE    := \
 		-I$(SRCTREE)/include/arch/$(PLATFORM)/ \
 		-I$(SRCTREE)/include/openssl/
 
- COMM_FLAGS := -nostdinc  $(COMPILEINC) \
+ COMM_FLAGS :=  $(COMPILEINC) \
 	-g  -Os   -fno-common \
 	-ffunction-sections \
 	-fno-builtin -ffreestanding \


### PR DESCRIPTION
This helps building on different kind of toolchains e.g. OE/Yocto where
the standard install paths may vary and this is better to avoid to have
to poke into system to find headers etc.

Signed-off-by: Khem Raj <raj.khem@gmail.com>