### PR TITLE
Correct 'make' to $MAKE

### DIFF
--- a/drivers/dram/sun20iw1p1/Makefile
+++ b/drivers/dram/sun20iw1p1/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/mk/config.mk
 
 all:
 ifeq ($(notdir $(shell find ./ -name lib-dram)), lib-dram)
-	make -C lib-dram
+	$(MAKE) -C lib-dram
 else
 	@echo "libdram exist"
 endif


### PR DESCRIPTION
FreeBSD uses 'gmake' instead.

Signed-off-by: Julien Cassette <julien.cassette@gmail.com>